### PR TITLE
Add simple auth system

### DIFF
--- a/backend/lib/poster_board/users.ex
+++ b/backend/lib/poster_board/users.ex
@@ -1,0 +1,34 @@
+defmodule PosterBoard.Users do
+  @moduledoc "User management and authentication"
+  alias PosterBoard.Repo
+  alias PosterBoard.Users.User
+
+  def get_user_by_email(email) when is_binary(email) do
+    Repo.get_by(User, email: email)
+  end
+
+  def create_user(attrs) do
+    %User{}
+    |> User.changeset(%{
+      email: Map.get(attrs, "email"),
+      encrypted_password: hash_password(Map.get(attrs, "password"))
+    })
+    |> Repo.insert()
+  end
+
+  def authenticate_user(email, password) do
+    case get_user_by_email(email) do
+      nil -> {:error, :invalid_credentials}
+      user ->
+        if user.encrypted_password == hash_password(password) do
+          {:ok, user}
+        else
+          {:error, :invalid_credentials}
+        end
+    end
+  end
+
+  def hash_password(password) when is_binary(password) do
+    :crypto.hash(:sha256, password) |> Base.encode16(case: :lower)
+  end
+end

--- a/backend/lib/poster_board/users/user.ex
+++ b/backend/lib/poster_board/users/user.ex
@@ -12,5 +12,6 @@ defmodule PosterBoard.Users.User do
     user
     |> cast(attrs, [:email, :encrypted_password])
     |> validate_required([:email])
+    |> unique_constraint(:email)
   end
 end

--- a/backend/lib/poster_board_web/controllers/auth_controller.ex
+++ b/backend/lib/poster_board_web/controllers/auth_controller.ex
@@ -1,0 +1,35 @@
+defmodule PosterBoardWeb.AuthController do
+  use PosterBoardWeb, :controller
+  alias PosterBoard.Users
+  alias PosterBoardWeb.Endpoint
+
+  def register(conn, params) do
+    case Users.create_user(params) do
+      {:ok, _user} -> json(conn, %{status: "ok"})
+      {:error, changeset} ->
+        conn
+        |> put_status(:bad_request)
+        |> json(%{errors: translate_errors(changeset)})
+    end
+  end
+
+  def login(conn, %{"email" => email, "password" => password}) do
+    case Users.authenticate_user(email, password) do
+      {:ok, user} ->
+        token = Phoenix.Token.sign(Endpoint, "user salt", user.id)
+        json(conn, %{token: token})
+      {:error, _} ->
+        conn
+        |> put_status(:unauthorized)
+        |> json(%{error: "invalid_credentials"})
+    end
+  end
+
+  defp translate_errors(changeset) do
+    Ecto.Changeset.traverse_errors(changeset, fn {msg, opts} ->
+      Enum.reduce(opts, msg, fn {key, value}, acc ->
+        String.replace(acc, "%{#{key}}", to_string(value))
+      end)
+    end)
+  end
+end

--- a/backend/lib/poster_board_web/router.ex
+++ b/backend/lib/poster_board_web/router.ex
@@ -12,6 +12,8 @@ defmodule PosterBoardWeb.Router do
 
   scope "/api", PosterBoardWeb do
     pipe_through :api
+    post "/register", AuthController, :register
+    post "/login", AuthController, :login
     get "/swagger", SwaggerController, :swagger_json
   end
 end

--- a/backend/test/auth_controller_test.exs
+++ b/backend/test/auth_controller_test.exs
@@ -1,0 +1,34 @@
+defmodule PosterBoardWeb.AuthControllerTest do
+  use ExUnit.Case, async: true
+  use Plug.Test
+
+  alias PosterBoardWeb.Router
+  alias PosterBoard.Repo
+
+  setup do
+    :ok = Ecto.Adapters.SQL.Sandbox.checkout(Repo)
+  end
+
+  test "POST /api/register creates a user" do
+    conn =
+      conn(:post, "/api/register", Jason.encode!(%{email: "test@example.com", password: "secret"}))
+      |> put_req_header("content-type", "application/json")
+
+    conn = Router.call(conn, Router.init([]))
+    assert conn.status == 200
+    assert Repo.get_by(PosterBoard.Users.User, email: "test@example.com")
+  end
+
+  test "POST /api/login returns a token" do
+    {:ok, _} = PosterBoard.Users.create_user(%{"email" => "a@b.com", "password" => "pw"})
+
+    conn =
+      conn(:post, "/api/login", Jason.encode!(%{email: "a@b.com", password: "pw"}))
+      |> put_req_header("content-type", "application/json")
+
+    conn = Router.call(conn, Router.init([]))
+    assert conn.status == 200
+    body = Jason.decode!(conn.resp_body)
+    assert Map.has_key?(body, "token")
+  end
+end

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -4,6 +4,8 @@ import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import Dashboard from './pages/Dashboard';
 import Calendar from './pages/Calendar';
 import JobFeed from './pages/JobFeed';
+import Login from './pages/Login';
+import Register from './pages/Register';
 import { ColorModeProvider } from './theme/ColorModeContext';
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
@@ -14,6 +16,8 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
           <Route path="/" element={<Dashboard />} />
           <Route path="/calendar" element={<Calendar />} />
           <Route path="/jobs" element={<JobFeed />} />
+          <Route path="/login" element={<Login />} />
+          <Route path="/register" element={<Register />} />
         </Routes>
       </BrowserRouter>
     </ColorModeProvider>

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -1,0 +1,40 @@
+import React, { useState } from 'react';
+import { Box, Button, Container, Paper, TextField, Typography } from '@mui/material';
+import { useNavigate } from 'react-router-dom';
+
+export default function Login() {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const navigate = useNavigate();
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const res = await fetch('/api/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email, password }),
+    });
+    if (res.ok) {
+      const data = await res.json();
+      localStorage.setItem('token', data.token);
+      navigate('/');
+    }
+  };
+
+  return (
+    <Container maxWidth="sm" sx={{ mt: 8 }}>
+      <Paper sx={{ p: 4 }}>
+        <Typography variant="h5" sx={{ mb: 2 }}>
+          Login
+        </Typography>
+        <Box component="form" onSubmit={handleSubmit}>
+          <TextField label="Email" fullWidth margin="normal" value={email} onChange={(e) => setEmail(e.target.value)} />
+          <TextField label="Password" type="password" fullWidth margin="normal" value={password} onChange={(e) => setPassword(e.target.value)} />
+          <Button type="submit" variant="contained" fullWidth sx={{ mt: 2 }}>
+            Login
+          </Button>
+        </Box>
+      </Paper>
+    </Container>
+  );
+}

--- a/frontend/src/pages/Register.tsx
+++ b/frontend/src/pages/Register.tsx
@@ -1,0 +1,38 @@
+import React, { useState } from 'react';
+import { Box, Button, Container, Paper, TextField, Typography } from '@mui/material';
+import { useNavigate } from 'react-router-dom';
+
+export default function Register() {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const navigate = useNavigate();
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const res = await fetch('/api/register', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email, password }),
+    });
+    if (res.ok) {
+      navigate('/login');
+    }
+  };
+
+  return (
+    <Container maxWidth="sm" sx={{ mt: 8 }}>
+      <Paper sx={{ p: 4 }}>
+        <Typography variant="h5" sx={{ mb: 2 }}>
+          Register
+        </Typography>
+        <Box component="form" onSubmit={handleSubmit}>
+          <TextField label="Email" fullWidth margin="normal" value={email} onChange={(e) => setEmail(e.target.value)} />
+          <TextField label="Password" type="password" fullWidth margin="normal" value={password} onChange={(e) => setPassword(e.target.value)} />
+          <Button type="submit" variant="contained" fullWidth sx={{ mt: 2 }}>
+            Register
+          </Button>
+        </Box>
+      </Paper>
+    </Container>
+  );
+}


### PR DESCRIPTION
## Summary
- add Users context and password hashing
- create AuthController with register/login actions
- expose routes for register and login
- make register/login pages in React
- hook pages into router
- cover auth API in tests

## Testing
- `npm test -- --watchAll=false` *(fails: jest not found)*
- `mix test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b678ef85883319cedb07241f98943