### PR TITLE
Implement ErrorView for JSON error responses

### DIFF
--- a/backend/lib/poster_board_web/error_view.ex
+++ b/backend/lib/poster_board_web/error_view.ex
@@ -1,0 +1,17 @@
+defmodule PosterBoardWeb.ErrorView do
+  use PosterBoardWeb, :view
+
+  def render("404.json", _assigns) do
+    %{errors: %{detail: "Not Found"}}
+  end
+
+  def render("500.json", _assigns) do
+    %{errors: %{detail: "Internal Server Error"}}
+  end
+
+  # In case no render clause matches or no
+  # template is found, let's render it as 500
+  def template_not_found(_template, assigns) do
+    render("500.json", assigns)
+  end
+end


### PR DESCRIPTION
## Summary
- handle API errors by defining `PosterBoardWeb.ErrorView`

## Testing
- `mix test` *(fails: `mix: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685bf8f5bab48331b4e96c450310be77