### PR TITLE
Implement SSE endpoint to fix 404

### DIFF
--- a/backend/lib/poster_board_web/controllers/job_controller.ex
+++ b/backend/lib/poster_board_web/controllers/job_controller.ex
@@ -1,0 +1,20 @@
+defmodule PosterBoardWeb.JobController do
+  use PosterBoardWeb, :controller
+
+  @doc """
+  Stream job postings using Server-Sent Events (SSE).
+  Currently streams a placeholder event so the endpoint exists
+  without returning a 404.
+  """
+  def stream(conn, _params) do
+    conn =
+      conn
+      |> put_resp_header("cache-control", "no-cache")
+      |> put_resp_header("content-type", "text/event-stream")
+      |> send_chunked(200)
+
+    # send an empty JSON object as a placeholder event
+    _ = chunk(conn, "data: {}\n\n")
+    conn
+  end
+end

--- a/backend/lib/poster_board_web/router.ex
+++ b/backend/lib/poster_board_web/router.ex
@@ -14,6 +14,7 @@ defmodule PosterBoardWeb.Router do
     pipe_through :api
     post "/register", AuthController, :register
     post "/login", AuthController, :login
+    get "/jobs/stream", JobController, :stream
     get "/swagger", SwaggerController, :swagger_json
   end
 end

--- a/backend/test/job_controller_test.exs
+++ b/backend/test/job_controller_test.exs
@@ -1,0 +1,11 @@
+defmodule PosterBoardWeb.JobControllerTest do
+  use ExUnit.Case, async: true
+  use Plug.Test
+  alias PosterBoardWeb.Router
+
+  test "GET /api/jobs/stream returns 200" do
+    conn = conn(:get, "/api/jobs/stream")
+    conn = Router.call(conn, Router.init([]))
+    assert conn.status == 200
+  end
+end


### PR DESCRIPTION
## Summary
- add placeholder JobController with `/api/jobs/stream` SSE route
- update router to expose the new stream endpoint
- add basic test ensuring the endpoint responds

## Testing
- `mix test` *(fails: `mix: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685bfeaaccb48331979fb3d264402f62