### PR TITLE
Fix API base URL in frontend

### DIFF
--- a/frontend/src/pages/JobFeed.tsx
+++ b/frontend/src/pages/JobFeed.tsx
@@ -3,6 +3,6 @@ import JobCard from '../components/JobCard';
 import { useSSE } from '../hooks/useSSE';
 
 export default function JobFeed() {
-  const job = useSSE<any>(`/api/jobs/stream`);
+  const job = useSSE<any>(`${import.meta.env.VITE_API_URL}/api/jobs/stream`);
   return <JobCard job={job} />;
 }

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -9,7 +9,7 @@ export default function Login() {
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    const res = await fetch('/api/login', {
+    const res = await fetch(`${import.meta.env.VITE_API_URL}/api/login`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ email, password }),

--- a/frontend/src/pages/Register.tsx
+++ b/frontend/src/pages/Register.tsx
@@ -9,7 +9,7 @@ export default function Register() {
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    const res = await fetch('/api/register', {
+    const res = await fetch(`${import.meta.env.VITE_API_URL}/api/register`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ email, password }),


### PR DESCRIPTION
## Summary
- use `import.meta.env.VITE_API_URL` for API calls in Login/Register pages
- update job feed SSE to use the API base URL

## Testing
- `mix test` *(fails: `bash: mix: command not found`)*
- `npm test -- --watchAll=false` *(fails: `jest: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685c0251f9c4833186acdcb6fecd2bca