### PR TITLE
Add CORS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This is a starter kit for a personal productivity app with Elixir/Phoenix API an
 docker-compose up --build
 ```
 
+Copy `example.env` to `.env` and set `CORS_ORIGIN` to the frontend URL (default `http://localhost:3000`).
 The API will be available at `http://localhost:4000` and the frontend at `http://localhost:3000`.
 
 ## Tests

--- a/backend/lib/poster_board_web/endpoint.ex
+++ b/backend/lib/poster_board_web/endpoint.ex
@@ -21,5 +21,7 @@ defmodule PosterBoardWeb.Endpoint do
   plug Plug.Head
   plug Plug.Session, store: :cookie, key: "_poster_board_key", signing_salt: "salt"
 
+  plug CORSPlug, origin: [System.get_env("CORS_ORIGIN") || "*"]
+
   plug PosterBoardWeb.Router
 end

--- a/backend/mix.exs
+++ b/backend/mix.exs
@@ -33,6 +33,7 @@ defmodule PosterBoard.MixProject do
       {:postgrex, "~> 0.17"},
       {:plug_cowboy, "~> 2.6"},
       {:jason, "~> 1.4"},
+      {:cors_plug, "~> 3.0"},
       {:credo, "~> 1.7", only: [:dev, :test], runtime: false},
       {:dialyxir, "~> 1.4", only: [:dev, :test], runtime: false}
     ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,7 @@ services:
     environment:
       DATABASE_URL: ${DATABASE_URL}
       SECRET_KEY_BASE: ${SECRET_KEY_BASE}
+      CORS_ORIGIN: ${CORS_ORIGIN:-http://localhost:3000}
     ports:
       - '4000:4000'
     depends_on:

--- a/example.env
+++ b/example.env
@@ -8,3 +8,5 @@ POOL_SIZE=10
 PORT=4000
 # URL of the backend API consumed by the React frontend
 VITE_API_URL=http://localhost:4000
+# Allowed origins for CORS
+CORS_ORIGIN=http://localhost:3000


### PR DESCRIPTION
## Summary
- support CORS from configurable origin
- document how to set `CORS_ORIGIN`

## Testing
- `mix test` *(fails: `mix: command not found`)*
- `npm test -- --watchAll=false` *(fails: `jest: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685c087bda448331a981aae2a6967df4