### PR TITLE
Add dashboard layout and redirect

### DIFF
--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -1,5 +1,25 @@
 import React from 'react';
+import { Card, CardContent, Grid } from '@mui/material';
+import JobFeed from './JobFeed';
+import Calendar from './Calendar';
 
 export default function Dashboard() {
-  return <div>Dashboard</div>;
+  return (
+    <Grid container spacing={2} sx={{ mt: 2 }}>
+      <Grid item xs={12} md={6}>
+        <Card>
+          <CardContent>
+            <JobFeed />
+          </CardContent>
+        </Card>
+      </Grid>
+      <Grid item xs={12} md={6}>
+        <Card>
+          <CardContent>
+            <Calendar />
+          </CardContent>
+        </Card>
+      </Grid>
+    </Grid>
+  );
 }

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -17,7 +17,7 @@ export default function Login() {
     if (res.ok) {
       const data = await res.json();
       localStorage.setItem('token', data.token);
-      navigate('/');
+      navigate('/dashboard');
     }
   };
 


### PR DESCRIPTION
## Summary
- redirect user to `/dashboard` after logging in
- replace Dashboard with card layout showing job feed and calendar

## Testing
- `npm --prefix frontend test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c0bf334888331bcd1bfaf5f5c056d