### PR TITLE
Add LinkedIn job feed with keyword filters

### DIFF
--- a/backend/lib/poster_board/job_feed/linkedin.ex
+++ b/backend/lib/poster_board/job_feed/linkedin.ex
@@ -1,0 +1,47 @@
+defmodule PosterBoard.JobFeed.LinkedIn do
+  @moduledoc """
+  Fetch jobs from LinkedIn job search.
+
+  This implementation uses LinkedIn's public job search endpoint and parses the
+  resulting HTML to extract job information. It should be considered a best
+  effort placeholder and may break if LinkedIn changes their markup.
+  """
+
+  @endpoint "https://www.linkedin.com/jobs-guest/jobs/api/seeMoreJobPostings/search"
+
+  @doc """
+  Fetch jobs matching the given keywords.
+
+  `keywords` can be either a list of words or a single string. Returns a list of
+  maps with `:title`, `:company` and `:url` keys.
+  """
+  def fetch_jobs(keywords) when is_list(keywords) do
+    keywords
+    |> Enum.join(" ")
+    |> fetch_jobs()
+  end
+
+  def fetch_jobs(keywords) when is_binary(keywords) do
+    url = @endpoint <> "?keywords=" <> URI.encode(keywords)
+
+    with {:ok, %{status: 200, body: body}} <- Req.get(url) do
+      parse_html(body)
+    else
+      _ -> []
+    end
+  end
+
+  defp parse_html(html) do
+    {:ok, document} = Floki.parse_document(html)
+
+    document
+    |> Floki.find("li")
+    |> Enum.map(fn li ->
+      %{
+        title: li |> Floki.find("h3") |> Floki.text() |> String.trim(),
+        company: li |> Floki.find(".base-search-card__subtitle") |> Floki.text() |> String.trim(),
+        url: li |> Floki.find("a") |> Floki.attribute("href") |> List.first()
+      }
+    end)
+  end
+end

--- a/backend/lib/poster_board_web/controllers/job_controller.ex
+++ b/backend/lib/poster_board_web/controllers/job_controller.ex
@@ -2,19 +2,31 @@ defmodule PosterBoardWeb.JobController do
   use PosterBoardWeb, :controller
 
   @doc """
-  Stream job postings using Server-Sent Events (SSE).
-  Currently streams a placeholder event so the endpoint exists
-  without returning a 404.
+  Stream job postings from LinkedIn using Server-Sent Events (SSE).
+
+  Optional query parameter `keywords` may be provided as a comma separated list
+  which will be used to filter LinkedIn results.
   """
-  def stream(conn, _params) do
+  def stream(conn, params) do
+    keywords =
+      params
+      |> Map.get("keywords", "")
+      |> String.split(",", trim: true)
+
+    jobs = PosterBoard.JobFeed.LinkedIn.fetch_jobs(keywords)
+
     conn =
       conn
       |> put_resp_header("cache-control", "no-cache")
       |> put_resp_header("content-type", "text/event-stream")
       |> send_chunked(200)
 
-    # send an empty JSON object as a placeholder event
-    _ = chunk(conn, "data: {}\n\n")
-    conn
+    Enum.reduce_while(jobs, conn, fn job, conn ->
+      payload = "data: " <> Jason.encode!(job) <> "\n\n"
+      case chunk(conn, payload) do
+        {:ok, conn} -> {:cont, conn}
+        {:error, _} -> {:halt, conn}
+      end
+    end)
   end
 end

--- a/backend/lib/poster_board_web/router.ex
+++ b/backend/lib/poster_board_web/router.ex
@@ -2,7 +2,7 @@ defmodule PosterBoardWeb.Router do
   use PosterBoardWeb, :router
 
   pipeline :api do
-    plug :accepts, ["json"]
+    plug :accepts, ["json", "event-stream"]
   end
 
   scope "/", PosterBoardWeb do

--- a/backend/mix.exs
+++ b/backend/mix.exs
@@ -34,6 +34,8 @@ defmodule PosterBoard.MixProject do
       {:plug_cowboy, "~> 2.6"},
       {:jason, "~> 1.4"},
       {:cors_plug, "~> 3.0"},
+      {:req, "~> 0.4"},
+      {:floki, "~> 0.34"},
       {:credo, "~> 1.7", only: [:dev, :test], runtime: false},
       {:dialyxir, "~> 1.4", only: [:dev, :test], runtime: false}
     ]


### PR DESCRIPTION
## Summary
- allow `event-stream` requests in the API router
- implement LinkedIn job feed adapter and keyword filtering
- expose jobs via SSE
- add required HTTP/HTML parsing deps

## Testing
- `mix test` *(fails: `mix` not found)*
- `npm test -- --watchAll=false` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c0ec89130833197235360cbce8f8e