### PR TITLE
Fix SSE mime type

### DIFF
--- a/backend/config/config.exs
+++ b/backend/config/config.exs
@@ -10,6 +10,13 @@ config :poster_board, PosterBoardWeb.Endpoint,
   # signing salt here.
   # live_view: [signing_salt: "SECRET"]
 
+# Register the MIME type used for Server-Sent Events so that
+# `plug :accepts, ["json", "event-stream"]` properly negotiates
+# requests with the "text/event-stream" header.
+config :mime, :types, %{
+  "text/event-stream" => ["event-stream"]
+}
+
 config :logger, level: :info
 
 import_config "#{config_env()}.exs"


### PR DESCRIPTION
## Summary
- register `text/event-stream` MIME type so SSE feed works

## Testing
- `mix test` *(fails: `bash: mix: command not found`)*
- `npm test -- --watchAll=false` *(fails: `jest: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685c18ab6bdc8331a210007e10026baf