### PR TITLE
Add console logging for job SSE payload

### DIFF
--- a/frontend/src/hooks/useSSE.ts
+++ b/frontend/src/hooks/useSSE.ts
@@ -4,7 +4,11 @@ export const useSSE = <T>(url: string) => {
   const [data, setData] = useState<T | null>(null);
   useEffect(() => {
     const evtSource = new EventSource(url);
-    evtSource.onmessage = (e) => setData(JSON.parse(e.data));
+    evtSource.onmessage = (e) => {
+      const parsed = JSON.parse(e.data);
+      console.log('SSE payload:', parsed);
+      setData(parsed);
+    };
     return () => evtSource.close();
   }, [url]);
   return data;


### PR DESCRIPTION
## Summary
- log each SSE payload in useSSE hook so incoming job data is visible in browser console

## Testing
- `npm --prefix frontend test -- --watchAll=false` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c248f7d8883318293474de3ca86fa