### PR TITLE
Add keyword filters with navbar

### DIFF
--- a/backend/lib/poster_board/keywords.ex
+++ b/backend/lib/poster_board/keywords.ex
@@ -1,0 +1,25 @@
+defmodule PosterBoard.Keywords do
+  @moduledoc "Manage user search keywords"
+  import Ecto.Query
+  alias PosterBoard.Repo
+  alias PosterBoard.Keywords.Keyword
+  alias PosterBoard.Users.User
+
+  def list_keywords(%User{id: user_id}) do
+    Repo.all(from k in Keyword, where: k.user_id == ^user_id)
+  end
+
+  def get_keyword!(%User{id: user_id}, id) do
+    Repo.get_by!(Keyword, id: id, user_id: user_id)
+  end
+
+  def create_keyword(%User{id: user_id}, attrs) do
+    %Keyword{user_id: user_id}
+    |> Keyword.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  def delete_keyword(%Keyword{} = keyword) do
+    Repo.delete(keyword)
+  end
+end

--- a/backend/lib/poster_board/keywords/keyword.ex
+++ b/backend/lib/poster_board/keywords/keyword.ex
@@ -1,0 +1,16 @@
+defmodule PosterBoard.Keywords.Keyword do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  schema "keywords" do
+    field :word, :string
+    belongs_to :user, PosterBoard.Users.User
+    timestamps()
+  end
+
+  def changeset(keyword, attrs) do
+    keyword
+    |> cast(attrs, [:word, :user_id])
+    |> validate_required([:word, :user_id])
+  end
+end

--- a/backend/lib/poster_board/users.ex
+++ b/backend/lib/poster_board/users.ex
@@ -3,6 +3,8 @@ defmodule PosterBoard.Users do
   alias PosterBoard.Repo
   alias PosterBoard.Users.User
 
+  def get_user(id) when is_integer(id), do: Repo.get(User, id)
+
   def get_user_by_email(email) when is_binary(email) do
     Repo.get_by(User, email: email)
   end

--- a/backend/lib/poster_board_web/controllers/keyword_controller.ex
+++ b/backend/lib/poster_board_web/controllers/keyword_controller.ex
@@ -1,0 +1,34 @@
+defmodule PosterBoardWeb.KeywordController do
+  use PosterBoardWeb, :controller
+  alias PosterBoard.Keywords
+  plug PosterBoardWeb.AuthPlug
+
+  def index(conn, _params) do
+    keywords = Keywords.list_keywords(conn.assigns.current_user)
+    json(conn, keywords)
+  end
+
+  def create(conn, %{"word" => word}) do
+    case Keywords.create_keyword(conn.assigns.current_user, %{word: word}) do
+      {:ok, keyword} -> json(conn, keyword)
+      {:error, changeset} ->
+        conn
+        |> put_status(:bad_request)
+        |> json(%{errors: translate_errors(changeset)})
+    end
+  end
+
+  def delete(conn, %{"id" => id}) do
+    keyword = Keywords.get_keyword!(conn.assigns.current_user, String.to_integer(id))
+    {:ok, _} = Keywords.delete_keyword(keyword)
+    send_resp(conn, 204, "")
+  end
+
+  defp translate_errors(changeset) do
+    Ecto.Changeset.traverse_errors(changeset, fn {msg, opts} ->
+      Enum.reduce(opts, msg, fn {key, value}, acc ->
+        String.replace(acc, "%{#{key}}", to_string(value))
+      end)
+    end)
+  end
+end

--- a/backend/lib/poster_board_web/controllers/user_controller.ex
+++ b/backend/lib/poster_board_web/controllers/user_controller.ex
@@ -1,0 +1,44 @@
+defmodule PosterBoardWeb.UserController do
+  use PosterBoardWeb, :controller
+  plug PosterBoardWeb.AuthPlug
+
+  def me(conn, _params) do
+    user = conn.assigns.current_user
+    json(conn, %{id: user.id, email: user.email})
+  end
+end
+cat > backend/lib/poster_board_web/controllers/keyword_controller.ex
+defmodule PosterBoardWeb.KeywordController do
+  use PosterBoardWeb, :controller
+  alias PosterBoard.Keywords
+  plug PosterBoardWeb.AuthPlug
+
+  def index(conn, _params) do
+    keywords = Keywords.list_keywords(conn.assigns.current_user)
+    json(conn, keywords)
+  end
+
+  def create(conn, %{"word" => word}) do
+    case Keywords.create_keyword(conn.assigns.current_user, %{word: word}) do
+      {:ok, keyword} -> json(conn, keyword)
+      {:error, changeset} ->
+        conn
+        |> put_status(:bad_request)
+        |> json(%{errors: translate_errors(changeset)})
+    end
+  end
+
+  def delete(conn, %{"id" => id}) do
+    keyword = Keywords.get_keyword!(conn.assigns.current_user, String.to_integer(id))
+    {:ok, _} = Keywords.delete_keyword(keyword)
+    send_resp(conn, 204, "")
+  end
+
+  defp translate_errors(changeset) do
+    Ecto.Changeset.traverse_errors(changeset, fn {msg, opts} ->
+      Enum.reduce(opts, msg, fn {key, value}, acc ->
+        String.replace(acc, "%{#{key}}", to_string(value))
+      end)
+    end)
+  end
+end

--- a/backend/lib/poster_board_web/plugs/auth_plug.ex
+++ b/backend/lib/poster_board_web/plugs/auth_plug.ex
@@ -1,0 +1,20 @@
+defmodule PosterBoardWeb.AuthPlug do
+  import Plug.Conn
+  alias PosterBoard.Users
+  alias PosterBoardWeb.Endpoint
+
+  def init(opts), do: opts
+
+  def call(conn, _opts) do
+    with ["Bearer " <> token] <- get_req_header(conn, "authorization"),
+         {:ok, user_id} <- Phoenix.Token.verify(Endpoint, "user salt", token, max_age: 14 * 24 * 3600),
+         user when not is_nil(user) <- Users.get_user(user_id) do
+      assign(conn, :current_user, user)
+    else
+      _ ->
+        conn
+        |> send_resp(401, "unauthorized")
+        |> halt()
+    end
+  end
+end

--- a/backend/lib/poster_board_web/router.ex
+++ b/backend/lib/poster_board_web/router.ex
@@ -5,6 +5,10 @@ defmodule PosterBoardWeb.Router do
     plug :accepts, ["json", "event-stream"]
   end
 
+  pipeline :auth do
+    plug PosterBoardWeb.AuthPlug
+  end
+
   scope "/", PosterBoardWeb do
     pipe_through :api
     get "/health", HealthController, :index
@@ -16,5 +20,13 @@ defmodule PosterBoardWeb.Router do
     post "/login", AuthController, :login
     get "/jobs/stream", JobController, :stream
     get "/swagger", SwaggerController, :swagger_json
+  end
+
+  scope "/api", PosterBoardWeb do
+    pipe_through [:api, :auth]
+    get "/me", UserController, :me
+    get "/keywords", KeywordController, :index
+    post "/keywords", KeywordController, :create
+    delete "/keywords/:id", KeywordController, :delete
   end
 end

--- a/backend/priv/repo/migrations/20240102000000_create_keywords.exs
+++ b/backend/priv/repo/migrations/20240102000000_create_keywords.exs
@@ -1,0 +1,13 @@
+defmodule PosterBoard.Repo.Migrations.CreateKeywords do
+  use Ecto.Migration
+
+  def change do
+    create table(:keywords) do
+      add :word, :string
+      add :user_id, references(:users)
+      timestamps()
+    end
+
+    create index(:keywords, [:user_id])
+  end
+end

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -1,0 +1,28 @@
+import React, { useEffect, useState } from 'react';
+import { AppBar, Toolbar, Typography, Box } from '@mui/material';
+import { User } from '../hooks/useCurrentUser';
+
+export default function Navbar({ user }: { user: User | null }) {
+  const [now, setNow] = useState(new Date());
+
+  useEffect(() => {
+    const id = setInterval(() => setNow(new Date()), 60000);
+    return () => clearInterval(id);
+  }, []);
+
+  const time = now.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+  const date = now.toLocaleDateString('en-US');
+
+  return (
+    <AppBar position="static" sx={{ mb: 2 }}>
+      <Toolbar>
+        <Typography variant="h6" sx={{ flexGrow: 1 }}>
+          {time} {date}
+        </Typography>
+        <Box sx={{ ml: 'auto' }}>
+          <Typography>{user?.email}</Typography>
+        </Box>
+      </Toolbar>
+    </AppBar>
+  );
+}

--- a/frontend/src/hooks/useCurrentUser.ts
+++ b/frontend/src/hooks/useCurrentUser.ts
@@ -1,0 +1,23 @@
+import { useEffect, useState } from 'react';
+
+export interface User {
+  id: number;
+  email: string;
+}
+
+export const useCurrentUser = () => {
+  const [user, setUser] = useState<User | null>(null);
+  const token = localStorage.getItem('token');
+
+  useEffect(() => {
+    if (!token) return;
+    fetch(`${import.meta.env.VITE_API_URL}/api/me`, {
+      headers: { Authorization: `Bearer ${token}` },
+    })
+      .then((res) => (res.ok ? res.json() : null))
+      .then((u) => setUser(u))
+      .catch(() => {});
+  }, [token]);
+
+  return user;
+};

--- a/frontend/src/hooks/useKeywords.ts
+++ b/frontend/src/hooks/useKeywords.ts
@@ -1,0 +1,50 @@
+import { useEffect, useState } from 'react';
+
+export interface Keyword {
+  id: number;
+  word: string;
+}
+
+export const useKeywords = () => {
+  const [keywords, setKeywords] = useState<Keyword[]>([]);
+  const token = localStorage.getItem('token');
+
+  useEffect(() => {
+    if (!token) return;
+    fetch(`${import.meta.env.VITE_API_URL}/api/keywords`, {
+      headers: { Authorization: `Bearer ${token}` },
+    })
+      .then((res) => res.ok ? res.json() : [])
+      .then(setKeywords)
+      .catch(() => {});
+  }, [token]);
+
+  const addKeyword = async (word: string) => {
+    if (!token) return;
+    const res = await fetch(`${import.meta.env.VITE_API_URL}/api/keywords`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({ word }),
+    });
+    if (res.ok) {
+      const kw = await res.json();
+      setKeywords((prev) => [...prev, kw]);
+    }
+  };
+
+  const removeKeyword = async (id: number) => {
+    if (!token) return;
+    const res = await fetch(`${import.meta.env.VITE_API_URL}/api/keywords/${id}`, {
+      method: 'DELETE',
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (res.ok) {
+      setKeywords((prev) => prev.filter((k) => k.id !== id));
+    }
+  };
+
+  return { keywords, addKeyword, removeKeyword };
+};

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -2,10 +2,15 @@ import React from 'react';
 import { Card, CardContent, Grid } from '@mui/material';
 import JobFeed from './JobFeed';
 import Calendar from './Calendar';
+import Navbar from '../components/Navbar';
+import { useCurrentUser } from '../hooks/useCurrentUser';
 
 export default function Dashboard() {
+  const user = useCurrentUser();
   return (
-    <Grid container spacing={2} sx={{ mt: 2 }}>
+    <>
+      <Navbar user={user} />
+      <Grid container spacing={2} sx={{ mt: 2 }}>
       <Grid item xs={12} md={6}>
         <Card>
           <CardContent>
@@ -20,6 +25,7 @@ export default function Dashboard() {
           </CardContent>
         </Card>
       </Grid>
-    </Grid>
+      </Grid>
+    </>
   );
 }

--- a/frontend/src/pages/JobFeed.tsx
+++ b/frontend/src/pages/JobFeed.tsx
@@ -1,8 +1,53 @@
-import React from 'react';
+import React, { useState } from 'react';
 import JobCard from '../components/JobCard';
 import { useSSE } from '../hooks/useSSE';
+import { TextField, Button, Chip, Box } from '@mui/material';
+import { useKeywords } from '../hooks/useKeywords';
+import Navbar from '../components/Navbar';
+import { useCurrentUser } from '../hooks/useCurrentUser';
 
 export default function JobFeed() {
-  const job = useSSE<any>(`${import.meta.env.VITE_API_URL}/api/jobs/stream`);
-  return <JobCard job={job} />;
+  const { keywords, addKeyword, removeKeyword } = useKeywords();
+  const user = useCurrentUser();
+  const [input, setInput] = useState('');
+  const query = keywords.map((k) => k.word).join(',');
+  const job = useSSE<any>(
+    `${import.meta.env.VITE_API_URL}/api/jobs/stream?keywords=${encodeURIComponent(query)}`,
+  );
+
+  const handleAdd = () => {
+    if (input.trim()) {
+      addKeyword(input.trim());
+      setInput('');
+    }
+  };
+
+  return (
+    <Box>
+      <Navbar user={user} />
+      <Box sx={{ display: 'flex', mb: 1 }}>
+        <TextField
+          label="Keyword"
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') {
+              e.preventDefault();
+              handleAdd();
+            }
+          }}
+          fullWidth
+        />
+        <Button sx={{ ml: 1 }} variant="contained" onClick={handleAdd}>
+          Add Keyword
+        </Button>
+      </Box>
+      <Box sx={{ mb: 2 }}>
+        {keywords.map((k) => (
+          <Chip key={k.id} label={k.word} onDelete={() => removeKeyword(k.id)} sx={{ mr: 1, mb: 1 }} />
+        ))}
+      </Box>
+      <JobCard job={job} />
+    </Box>
+  );
 }


### PR DESCRIPTION
## Summary
- create keywords table and context with CRUD helpers
- secure API with auth plug and expose `/api/keywords` and `/api/me`
- add navbar displaying date/time and current user
- allow entering search keywords via chips
- filter job feed by keywords

## Testing
- `mix test` *(fails: `mix: command not found`)*
- `npm test -- --watchAll=false` *(fails: `jest: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685c36a8274483318a4b322dc83235f4