### PR TITLE
Fix JSON encoding for keywords

### DIFF
--- a/backend/lib/poster_board/keywords/keyword.ex
+++ b/backend/lib/poster_board/keywords/keyword.ex
@@ -1,6 +1,8 @@
 defmodule PosterBoard.Keywords.Keyword do
+  @moduledoc false
   use Ecto.Schema
   import Ecto.Changeset
+  @derive {Jason.Encoder, only: [:id, :word]}
 
   schema "keywords" do
     field :word, :string


### PR DESCRIPTION
## Summary
- make `PosterBoard.Keywords.Keyword` encodable by Jason

## Testing
- `mix test` *(fails: `mix: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685c3cb034208331938ca72f537e4047