### PR TITLE
Fix Credo warnings

### DIFF
--- a/backend/lib/poster_board/application.ex
+++ b/backend/lib/poster_board/application.ex
@@ -1,4 +1,7 @@
 defmodule PosterBoard.Application do
+  @moduledoc """
+  OTP application entry module.
+  """
   use Application
 
   def start(_type, _args) do

--- a/backend/lib/poster_board/events/event.ex
+++ b/backend/lib/poster_board/events/event.ex
@@ -1,4 +1,7 @@
 defmodule PosterBoard.Events.Event do
+  @moduledoc """
+  Ecto schema representing a calendar event.
+  """
   use Ecto.Schema
   import Ecto.Changeset
 

--- a/backend/lib/poster_board/job_feed/linkedin.ex
+++ b/backend/lib/poster_board/job_feed/linkedin.ex
@@ -24,9 +24,8 @@ defmodule PosterBoard.JobFeed.LinkedIn do
   def fetch_jobs(keywords) when is_binary(keywords) do
     url = @endpoint <> "?keywords=" <> URI.encode(keywords)
 
-    with {:ok, %{status: 200, body: body}} <- Req.get(url) do
-      parse_html(body)
-    else
+    case Req.get(url) do
+      {:ok, %{status: 200, body: body}} -> parse_html(body)
       _ -> []
     end
   end

--- a/backend/lib/poster_board/jobs/job.ex
+++ b/backend/lib/poster_board/jobs/job.ex
@@ -1,4 +1,7 @@
 defmodule PosterBoard.Jobs.Job do
+  @moduledoc """
+  Ecto schema representing a job posting.
+  """
   use Ecto.Schema
   import Ecto.Changeset
 

--- a/backend/lib/poster_board/keywords.ex
+++ b/backend/lib/poster_board/keywords.ex
@@ -1,8 +1,8 @@
 defmodule PosterBoard.Keywords do
   @moduledoc "Manage user search keywords"
   import Ecto.Query
-  alias PosterBoard.Repo
   alias PosterBoard.Keywords.Keyword
+  alias PosterBoard.Repo
   alias PosterBoard.Users.User
 
   def list_keywords(%User{id: user_id}) do

--- a/backend/lib/poster_board/users/user.ex
+++ b/backend/lib/poster_board/users/user.ex
@@ -1,4 +1,7 @@
 defmodule PosterBoard.Users.User do
+  @moduledoc """
+  Ecto schema for application users.
+  """
   use Ecto.Schema
   import Ecto.Changeset
 

--- a/backend/lib/poster_board_web.ex
+++ b/backend/lib/poster_board_web.ex
@@ -1,4 +1,7 @@
 defmodule PosterBoardWeb do
+  @moduledoc """
+  Entry point for web components such as controllers and views.
+  """
   def controller do
     quote do
       use Phoenix.Controller, namespace: PosterBoardWeb

--- a/backend/lib/poster_board_web/controllers/job_controller.ex
+++ b/backend/lib/poster_board_web/controllers/job_controller.ex
@@ -1,5 +1,9 @@
 defmodule PosterBoardWeb.JobController do
+  @moduledoc """
+  Handles job related HTTP actions.
+  """
   use PosterBoardWeb, :controller
+  alias PosterBoard.JobFeed.LinkedIn
 
   @doc """
   Stream job postings from LinkedIn using Server-Sent Events (SSE).
@@ -13,7 +17,7 @@ defmodule PosterBoardWeb.JobController do
       |> Map.get("keywords", "")
       |> String.split(",", trim: true)
 
-    jobs = PosterBoard.JobFeed.LinkedIn.fetch_jobs(keywords)
+    jobs = LinkedIn.fetch_jobs(keywords)
 
     conn =
       conn

--- a/backend/lib/poster_board_web/plugs/auth_plug.ex
+++ b/backend/lib/poster_board_web/plugs/auth_plug.ex
@@ -1,4 +1,7 @@
 defmodule PosterBoardWeb.AuthPlug do
+  @moduledoc """
+  Plug for authenticating API requests.
+  """
   import Plug.Conn
   alias PosterBoard.Users
   alias PosterBoardWeb.Endpoint

--- a/backend/test/auth_controller_test.exs
+++ b/backend/test/auth_controller_test.exs
@@ -2,8 +2,8 @@ defmodule PosterBoardWeb.AuthControllerTest do
   use ExUnit.Case, async: true
   use Plug.Test
 
-  alias PosterBoardWeb.Router
   alias PosterBoard.Repo
+  alias PosterBoardWeb.Router
 
   setup do
     :ok = Ecto.Adapters.SQL.Sandbox.checkout(Repo)


### PR DESCRIPTION
## Summary
- add missing moduledocs
- alias LinkedIn job feed in `JobController`
- reorder aliases in modules
- replace single-clause `with` with `case`

## Testing
- `mix test` *(fails: mix not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c3f58ab288331915c4cbcbef09d62