### PR TITLE
Extend job feed with new sources and more info

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ cd ../frontend && npm test -- --watchAll=false
 ## Adding a Feed Adapter
 
 Implement a module under `PosterBoard.JobFeed` that fetches jobs from a new source and returns standardized job structs.
+Adapters for LinkedIn, Indeed and Glassdoor are provided as examples.
 
 ## Skeptical Checklist
 

--- a/backend/lib/poster_board/job_feed/glassdoor.ex
+++ b/backend/lib/poster_board/job_feed/glassdoor.ex
@@ -1,0 +1,53 @@
+defmodule PosterBoard.JobFeed.Glassdoor do
+  @moduledoc """
+  Fetch jobs from Glassdoor job search.
+
+  This is a best effort HTML scraper and may break if Glassdoor changes their markup.
+  """
+
+  @endpoint "https://www.glassdoor.com/Job/jobs.htm"
+
+  @doc """
+  Fetch jobs matching the given keywords.
+  Returns a list of maps with `:title`, `:company`, `:location`, `:summary` and `:url` keys.
+  """
+  def fetch_jobs(keywords) when is_list(keywords) do
+    keywords
+    |> Enum.join(" ")
+    |> fetch_jobs()
+  end
+
+  def fetch_jobs(keywords) when is_binary(keywords) do
+    url = @endpoint <> "?sc.keyword=" <> URI.encode(keywords)
+
+    case Req.get(url) do
+      {:ok, %{status: 200, body: body}} -> parse_html(body)
+      _ -> []
+    end
+  end
+
+  defp parse_html(html) do
+    {:ok, document} = Floki.parse_document(html)
+
+    document
+    |> Floki.find("li.react-job-listing")
+    |> Enum.map(fn li ->
+      %{
+        title: li |> Floki.find("a.jobLink") |> Floki.text() |> String.trim(),
+        company: li |> Floki.find(".job-search-1cbsw2k") |> Floki.text() |> String.trim(),
+        location: li |> Floki.find(".job-search-1v2wdoj") |> Floki.text() |> String.trim(),
+        summary: li |> Floki.find(".job-snippet") |> Floki.text() |> String.trim(),
+        url: li |> Floki.find("a.jobLink") |> Floki.attribute("href") |> List.first() |> normalize_url()
+      }
+    end)
+  end
+
+  defp normalize_url(nil), do: nil
+  defp normalize_url(url) do
+    if String.starts_with?(url, "http") do
+      url
+    else
+      "https://www.glassdoor.com" <> url
+    end
+  end
+end

--- a/backend/lib/poster_board/job_feed/indeed.ex
+++ b/backend/lib/poster_board/job_feed/indeed.ex
@@ -1,0 +1,53 @@
+defmodule PosterBoard.JobFeed.Indeed do
+  @moduledoc """
+  Fetch jobs from Indeed job search.
+
+  This is a best effort HTML scraper and may break if Indeed changes their markup.
+  """
+
+  @endpoint "https://www.indeed.com/jobs"
+
+  @doc """
+  Fetch jobs matching the given keywords.
+  Returns a list of maps with `:title`, `:company`, `:location`, `:summary` and `:url` keys.
+  """
+  def fetch_jobs(keywords) when is_list(keywords) do
+    keywords
+    |> Enum.join(" ")
+    |> fetch_jobs()
+  end
+
+  def fetch_jobs(keywords) when is_binary(keywords) do
+    url = @endpoint <> "?q=" <> URI.encode(keywords)
+
+    case Req.get(url) do
+      {:ok, %{status: 200, body: body}} -> parse_html(body)
+      _ -> []
+    end
+  end
+
+  defp parse_html(html) do
+    {:ok, document} = Floki.parse_document(html)
+
+    document
+    |> Floki.find("a.tapItem")
+    |> Enum.map(fn a ->
+      %{
+        title: a |> Floki.find("h2 span") |> Floki.text() |> String.trim(),
+        company: a |> Floki.find("span.companyName") |> Floki.text() |> String.trim(),
+        location: a |> Floki.find("div.companyLocation") |> Floki.text() |> String.trim(),
+        summary: a |> Floki.find("div.job-snippet") |> Floki.text() |> String.trim(),
+        url: a |> Floki.attribute("href") |> List.first() |> normalize_url()
+      }
+    end)
+  end
+
+  defp normalize_url(nil), do: nil
+  defp normalize_url(url) do
+    if String.starts_with?(url, "http") do
+      url
+    else
+      "https://www.indeed.com" <> url
+    end
+  end
+end

--- a/backend/lib/poster_board/job_feed/linkedin.ex
+++ b/backend/lib/poster_board/job_feed/linkedin.ex
@@ -13,7 +13,7 @@ defmodule PosterBoard.JobFeed.LinkedIn do
   Fetch jobs matching the given keywords.
 
   `keywords` can be either a list of words or a single string. Returns a list of
-  maps with `:title`, `:company` and `:url` keys.
+  maps with `:title`, `:company`, `:location`, `:summary` and `:url` keys.
   """
   def fetch_jobs(keywords) when is_list(keywords) do
     keywords
@@ -39,6 +39,8 @@ defmodule PosterBoard.JobFeed.LinkedIn do
       %{
         title: li |> Floki.find("h3") |> Floki.text() |> String.trim(),
         company: li |> Floki.find(".base-search-card__subtitle") |> Floki.text() |> String.trim(),
+        location: li |> Floki.find(".job-search-card__location") |> Floki.text() |> String.trim(),
+        summary: li |> Floki.find(".job-search-card__snippet") |> Floki.text() |> String.trim(),
         url: li |> Floki.find("a") |> Floki.attribute("href") |> List.first()
       }
     end)

--- a/frontend/src/components/JobCard.tsx
+++ b/frontend/src/components/JobCard.tsx
@@ -1,13 +1,27 @@
 import React from 'react';
-import { Card, CardContent, Typography } from '@mui/material';
+import { Card, CardContent, Typography, Link } from '@mui/material';
 
 export default function JobCard({ job }: { job: any }) {
   if (!job) return null;
   return (
     <Card sx={{ mb: 2 }}>
       <CardContent>
-        <Typography variant="h6">{job.title}</Typography>
+        <Typography variant="h6">
+          <Link href={job.url} target="_blank" rel="noopener noreferrer">
+            {job.title}
+          </Link>
+        </Typography>
         <Typography variant="subtitle2">{job.company}</Typography>
+        {job.location && (
+          <Typography variant="body2" color="text.secondary">
+            {job.location}
+          </Typography>
+        )}
+        {job.summary && (
+          <Typography variant="body2" sx={{ mt: 1 }}>
+            {job.summary}
+          </Typography>
+        )}
       </CardContent>
     </Card>
   );


### PR DESCRIPTION
## Summary
- add scrapers for Indeed and Glassdoor
- enhance LinkedIn scraper with summary and location
- combine all feeds in JobController and default to software/web dev keywords
- link titles in JobCard and show location/summary
- document new adapters in README

## Testing
- `mix test` *(fails: mix not found)*
- `npm test -- --watchAll=false` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c4312cfe4833180cb392a0ebd2e1a